### PR TITLE
Exclude 'Claude files' directory from package build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^pkgdown$
 ^doc$
 ^Meta$
+^Claude files$


### PR DESCRIPTION
## Summary
- Adds `^Claude files$` to `.Rbuildignore`

## Why
R CMD check on CI is failing with:
- WARNING: non-portable file names (the directory `Claude files` and the PDF inside it have spaces)
- NOTE: non-standard file/directory found at top level (`Claude files`)

Excluding the directory from the package build clears both. The directory and its contents stay in the repo and on disk — they just won't end up inside the built tarball.

## Test plan
- [ ] CI R-CMD-check passes (no WARNING, no NOTE for `Claude files`)